### PR TITLE
update libmapper API for mdev_timetag_now(), couple more important renames from firmata_mapper -> Firmapper.

### DIFF
--- a/Software/Firmapper_software/Firmapper.cpp
+++ b/Software/Firmapper_software/Firmapper.cpp
@@ -1079,7 +1079,7 @@ void MyFrame::Parse(const uint8_t *buf, int len)
   p = buf;
   end = p + len;
   
-  mdev_timetag_now(dev, &tt);
+  mdev_now(dev, &tt);
   mdev_start_queue(dev, tt);
   for (p = buf; p < end; p++) {
     uint8_t msn = *p & 0xF0;

--- a/Software/Firmapper_software/Info.plist
+++ b/Software/Firmapper_software/Info.plist
@@ -5,7 +5,7 @@
 	<key>CFBundleDisplayName</key>
 	<string>Firmata Mapper</string>
 	<key>CFBundleIdentifier</key>
-	<string>com.idmil.firmata_mapper</string>
+	<string>com.idmil.firmapper</string>
 	<key>CFBundleName</key>
 	<string>Firmata Mapper</string>
 	<key>CFBundleShortVersionString</key>
@@ -17,7 +17,7 @@
 	<key>NSAppleScriptEnabled</key>
 	<false/>
 	<key>CFBundleExecutable</key>
-	<string>firmata_mapper</string>
+	<string>Firmapper</string>
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleSignature</key>

--- a/Software/Firmapper_software/serial.cpp
+++ b/Software/Firmapper_software/serial.cpp
@@ -17,7 +17,7 @@
 
 #include <wx/wx.h>
 #include "serial.h"
-#include "firmata_mapper.h"
+#include "Firmapper.h"
 
 #if defined(LINUX)
   #include <sys/types.h>


### PR DESCRIPTION
- update libmapper API for mdev_timetag_now(), to mdev_now().
- couple more important renames from firmata_mapper -> Firmapper.
